### PR TITLE
Add override for Zope/Zope2 naming mismatch

### DIFF
--- a/get_zope_packages.py
+++ b/get_zope_packages.py
@@ -82,6 +82,12 @@ OVERRIDES = {
         'source_web_url': 'https://github.com/zodb/relstorage',
         'github_web_url': 'https://github.com/zodb/relstorage',
     },
+    # Zope2 is the PyPi name, Zope the github name
+    'Zope': {
+        'name': 'Zope2',
+        'source_web_url': 'https://github.com/zopefoundation/Zope',
+        'github_web_url': 'https://github.com/zopefoundation/Zope',
+    },
 }
 
 


### PR DESCRIPTION
This patch has been made without looking at the code too long, so I can be wrong here. I'm trying to normalize the github vs. PyPi naming so the Zope line picks up the correct dependencies.
